### PR TITLE
Template management - Template Creation Front End

### DIFF
--- a/web/app/components/new/template-form.hbs
+++ b/web/app/components/new/template-form.hbs
@@ -26,8 +26,8 @@
         <Hds::Form::TextInput::Field
           @type="text"
           @isRequired={{true}}
-          @value={{this.templateId}}
-          name="templateId"
+          @value={{this.templateName}}
+          name="templateName"
           placeholder="Enter new Template Id"
           {{on "input" this.updateForm}}
           as |F|

--- a/web/app/components/new/template-form.hbs
+++ b/web/app/components/new/template-form.hbs
@@ -1,0 +1,104 @@
+{{! @glint-nocheck: not typesafe yet }}
+{{!-- custom-template-add --}}
+{{#if this.docIsBeingCreated}}
+  <div class="text-center hds-typography-display-400 mt-3">
+    <FlightIcon @name="loading" @size="24" />
+    <div class="mt-8 text-display-200 font-semibold">
+      Creating New Template
+    </div>
+    <div class="text-body-200 text-color-foreground-faint">This usually takes
+      10-20 seconds.</div>
+  </div>
+{{else}}
+  <form
+    class="grid gap-10 grid-cols-[1fr_250px] grid-rows-1"
+    {{on "submit" this.submit}}
+    {{did-insert this.registerForm}}
+  >
+    <div>
+      <div class="space-y-4">
+        <h1
+          class="hds-typography-display-500 hds-font-weight-bold hds-foreground-strong"
+        >Create New Template</h1>
+      </div>
+      {{!-- template id  --}}
+      <div class="pt-10 space-y-7">
+        <Hds::Form::TextInput::Field
+          @type="text"
+          @isRequired={{true}}
+          @value={{this.templateId}}
+          name="templateId"
+          placeholder="Enter new Template Id"
+          {{on "input" this.updateForm}}
+          as |F|
+        >
+          <F.Label>Template ID</F.Label>
+        </Hds::Form::TextInput::Field>
+      </div>
+
+      {{!-- template longName --}}
+      <div class="pt-10 space-y-7">
+        <Hds::Form::TextInput::Field
+          @type="text"
+          @isRequired={{true}}
+          @value={{this.longName}}
+          name="longName"
+          placeholder="Enter Template long name"
+          {{on "input" this.updateForm}}
+          as |F|
+        >
+          <F.Label>Template long name</F.Label>
+        </Hds::Form::TextInput::Field>
+      </div>
+        <div class="h-12"></div>
+      {{!-- description --}}
+      <div class="relative">
+          <Hds::Form::Textarea::Field
+            @value={{this.description}}
+            rows="3"
+            name="description"
+            {{on "input" this.updateForm}}
+            as |F|
+          >
+            <F.Label>Description</F.Label>
+            <F.HelperText>
+              <span
+                class={{if
+                  this.descriptionIsLong
+                  "transition-colors bg-color-surface-warning text-color-foreground-warning-on-surface"
+                }}
+              >One or two sentences</span> outlining your Template.
+              {{if this.descriptionIsLong "(Just a recommendation)"}}
+            </F.HelperText>
+          </Hds::Form::Textarea::Field>
+      </div>
+
+      {{!-- doc id  --}}
+      <div class="pt-10 space-y-7">
+        <Hds::Form::TextInput::Field
+          @type="text"
+          @isRequired={{true}}
+          @value={{this.docId}}
+          name="docId"
+          placeholder="Enter existing google doc template link"
+          {{on "input" this.updateForm}}
+          as |F|
+        >
+          <F.Label>Document link</F.Label>
+        </Hds::Form::TextInput::Field>
+      </div>
+
+      <div class="h-24"></div>
+    </div>
+    <div>
+      <div class="preview-card">
+        <Hds::Button
+          @text="Create new template"
+          type="submit"
+          disabled={{not this.formRequirementsMet}}
+          class="w-full"
+        />
+      </div>
+    </div>
+  </form>
+{{/if}}

--- a/web/app/components/new/template-form.ts
+++ b/web/app/components/new/template-form.ts
@@ -14,14 +14,14 @@ import { assert } from "@ember/debug";
 import cleanString from "hermes/utils/clean-string";
 // custom-template-add
 interface DocFormErrors {
-  templateId: string | null;
+  templateName: string | null;
   longName: string | null;
   docId: string|null;
   description: string | null;
 }
 
 const FORM_ERRORS: DocFormErrors = {
-  templateId: null,
+  templateName: null,
   longName: null,
   docId: null,
   description: null,
@@ -40,7 +40,7 @@ export default class NewDocFormComponent extends Component<NewTemplateFormCompon
   @service declare modalAlerts: ModalAlertsService;
   @service declare router: RouterService;
 
-  @tracked protected templateId: string = "";
+  @tracked protected templateName: string = "";
   @tracked protected longName: string = "";
   @tracked protected docId: string = "";
   @tracked protected description: string = "";
@@ -49,7 +49,7 @@ export default class NewDocFormComponent extends Component<NewTemplateFormCompon
 
   /**
    * Whether the form has all required fields filled out.
-   * True if the templateId and product area are filled out.
+   * True if the templateName and product area are filled out.
    */
   @tracked protected formRequirementsMet = false;
 
@@ -100,7 +100,7 @@ export default class NewDocFormComponent extends Component<NewTemplateFormCompon
    */
   private maybeValidate() {
     
-    if (this.templateId && this.docId && this.longName) {
+    if (this.templateName && this.docId && this.longName) {
       this.formRequirementsMet = true;
     } else {
       this.formRequirementsMet = false;
@@ -138,9 +138,9 @@ export default class NewDocFormComponent extends Component<NewTemplateFormCompon
   @action protected updateForm() {
     const formObject = Object.fromEntries(new FormData(this.form).entries());
 
-    assert("templateId is missing from formObject", "templateId" in formObject);
+    assert("templateName is missing from formObject", "templateName" in formObject);
     assert("docId is missing from formObject", "docId" in formObject);
-    this.templateId = formObject["templateId"] as string;
+    this.templateName = formObject["templateName"] as string;
     this.longName = formObject["longName"] as string;
     this.docId = formObject["docId"] as string;
     this.description = formObject["description"] as string;
@@ -180,7 +180,7 @@ export default class NewDocFormComponent extends Component<NewTemplateFormCompon
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            templateId: cleanString(this.templateId),
+            templateName: cleanString(this.templateName),
             longName: cleanString(this.longName),
             docId: cleanString(this.docId),
             description: cleanString(this.description),
@@ -201,7 +201,7 @@ export default class NewDocFormComponent extends Component<NewTemplateFormCompon
     } catch (err: unknown) {
       this.docIsBeingCreated = false;
       this.flashMessages.add({
-        templateId: "Error creating template",
+        templateName: "Error creating template",
         message: `${err}`,
         type: "critical",
         timeout: 6000,

--- a/web/app/components/new/template-form.ts
+++ b/web/app/components/new/template-form.ts
@@ -1,0 +1,218 @@
+import Component from "@glimmer/component";
+import { task, timeout } from "ember-concurrency";
+import { inject as service } from "@ember/service";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import Ember from "ember";
+import FetchService from "hermes/services/fetch";
+import AuthenticatedUserService from "hermes/services/authenticated-user";
+import RouterService from "@ember/routing/router-service";
+import ModalAlertsService from "hermes/services/modal-alerts";
+import { HermesUser } from "hermes/types/document";
+import FlashService from "ember-cli-flash/services/flash-messages";
+import { assert } from "@ember/debug";
+import cleanString from "hermes/utils/clean-string";
+// custom-template-add
+interface DocFormErrors {
+  templateId: string | null;
+  longName: string | null;
+  docId: string|null;
+  description: string | null;
+}
+
+const FORM_ERRORS: DocFormErrors = {
+  templateId: null,
+  longName: null,
+  docId: null,
+  description: null,
+};
+
+const AWAIT_DOC_DELAY = Ember.testing ? 0 : 2000;
+const AWAIT_DOC_CREATED_MODAL_DELAY = Ember.testing ? 0 : 1500;
+
+interface NewTemplateFormComponentSignature {
+}
+
+export default class NewDocFormComponent extends Component<NewTemplateFormComponentSignature> {
+  @service("fetch") declare fetchSvc: FetchService;
+  @service declare authenticatedUser: AuthenticatedUserService;
+  @service declare flashMessages: FlashService;
+  @service declare modalAlerts: ModalAlertsService;
+  @service declare router: RouterService;
+
+  @tracked protected templateId: string = "";
+  @tracked protected longName: string = "";
+  @tracked protected docId: string = "";
+  @tracked protected description: string = "";
+
+  @tracked protected _form: HTMLFormElement | null = null;
+
+  /**
+   * Whether the form has all required fields filled out.
+   * True if the templateId and product area are filled out.
+   */
+  @tracked protected formRequirementsMet = false;
+
+  /**
+   * Whether the document is being created.
+   * Set true when the createDoc task is running.
+   * Reverted only if an error occurs.
+   */
+  @tracked protected docIsBeingCreated = false;
+
+  /**
+   * An object containing error messages for each applicable form field.
+   */
+  @tracked protected formErrors = { ...FORM_ERRORS };
+
+  /**
+   * Whether the description is more than 200 characters.
+   * Used in the template to gently discourage long summaries.
+   */
+
+  @tracked protected descriptionIsLong = false;
+
+
+  /**
+   * Whether to validate eagerly, that is, after every change to the form.
+   * Set true after an invalid submission attempt.
+   */
+  @tracked private validateEagerly = false;
+
+  /**
+   * The form element. Used to bind FormData to our tracked elements.
+   */
+  get form(): HTMLFormElement {
+    assert("_form must exist", this._form);
+    return this._form;
+  }
+
+  /**
+   * Whether the form has errors.
+   */
+  private get hasErrors(): boolean {
+    const defined = (a: unknown) => a != null;
+    return Object.values(this.formErrors).filter(defined).length > 0;
+  }
+
+  /**
+   * Sets `formRequirementsMet` and conditionally validates the form.
+   */
+  private maybeValidate() {
+    
+    if (this.templateId && this.docId && this.longName) {
+      this.formRequirementsMet = true;
+    } else {
+      this.formRequirementsMet = false;
+    }
+    if (this.validateEagerly) {
+      this.validate();
+    }
+  }
+
+  /**
+   * Validates the form and updates the `formErrors` property.
+   */
+  private validate() {
+    const errors = { ...FORM_ERRORS };
+    this.formErrors = errors;
+  }
+
+  /**
+   * Returns contributor emails as an array of strings.
+   */
+  private getEmails(values: HermesUser[]) {
+    return values.map((person) => person.email);
+  }
+
+  @action protected registerForm(form: HTMLFormElement) {
+    this._form = form;
+  }
+
+  /**
+   * Binds the FormData to our locally tracked properties.
+   * If the description is long, shows a gentle warning.
+   * Conditionally validates.
+   */
+  
+  @action protected updateForm() {
+    const formObject = Object.fromEntries(new FormData(this.form).entries());
+
+    assert("templateId is missing from formObject", "templateId" in formObject);
+    assert("docId is missing from formObject", "docId" in formObject);
+    this.templateId = formObject["templateId"] as string;
+    this.longName = formObject["longName"] as string;
+    this.docId = formObject["docId"] as string;
+    this.description = formObject["description"] as string;
+
+    if (this.description.length > 200) {
+      this.descriptionIsLong = true;
+    } else {
+      this.descriptionIsLong = false;
+    }
+
+    this.maybeValidate();
+  }
+
+  /**
+   * Validates the form, and, if valid, creates a document.
+   * If the form is invalid, sets `validateEagerly` true.
+   */
+  @action protected submit(event: SubmitEvent) {
+    event.preventDefault();
+    this.validateEagerly = true;
+    this.validate();
+    if (this.formRequirementsMet && !this.hasErrors) {
+      this.createDoc.perform();
+    }
+  }
+
+  /**
+   * Creates a document draft, then redirects to the document.
+   * On error, show a flashMessage and allow users to try again.
+   */
+  private createDoc = task(async () => {
+    this.docIsBeingCreated = true;
+
+    try {
+      const doc = await this.fetchSvc
+        .fetch("/api/v1/custom-template", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            templateId: cleanString(this.templateId),
+            longName: cleanString(this.longName),
+            docId: cleanString(this.docId),
+            description: cleanString(this.description),
+          }),
+        })
+        .then((response) => response?.json());
+
+      // Wait for document to be available.
+      await timeout(AWAIT_DOC_DELAY);
+
+      // Set modal on a delay so it appears after transition.
+      this.modalAlerts.setActive.perform(
+        "docCreated",
+        AWAIT_DOC_CREATED_MODAL_DELAY
+      );
+
+      this.router.transitionTo("authenticated.new");
+    } catch (err: unknown) {
+      this.docIsBeingCreated = false;
+      this.flashMessages.add({
+        templateId: "Error creating template",
+        message: `${err}`,
+        type: "critical",
+        timeout: 6000,
+        extendedTimeout: 1000,
+      });
+    }
+  });
+}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    "New::TemplateForm": typeof NewDocFormComponent;
+  }
+}

--- a/web/app/components/new/template-form.ts
+++ b/web/app/components/new/template-form.ts
@@ -192,10 +192,10 @@ export default class NewDocFormComponent extends Component<NewTemplateFormCompon
       await timeout(AWAIT_DOC_DELAY);
 
       // Set modal on a delay so it appears after transition.
-      this.modalAlerts.setActive.perform(
-        "docCreated",
-        AWAIT_DOC_CREATED_MODAL_DELAY
-      );
+      // this.modalAlerts.setActive.perform(
+      //   "docCreated",
+      //   AWAIT_DOC_CREATED_MODAL_DELAY
+      // );
 
       this.router.transitionTo("authenticated.new");
     } catch (err: unknown) {

--- a/web/app/config/environment.d.ts
+++ b/web/app/config/environment.d.ts
@@ -14,6 +14,7 @@ declare const config: {
     apiKey: string;
     docsIndexName: string;
     draftsIndexName: string;
+    templateIndexName: string,
     internalIndexName: string;
   };
   featureFlags: Record<string, boolean>;

--- a/web/app/router.js
+++ b/web/app/router.js
@@ -16,6 +16,7 @@ Router.map(function () {
     this.route("results");
     this.route("settings");
     this.route("new", function () {
+      this.route("custom-template")
       this.route("doc");
     });
   });

--- a/web/app/routes/authenticated/new/doc.js
+++ b/web/app/routes/authenticated/new/doc.js
@@ -42,7 +42,7 @@ export default class AuthenticatedNewDocRoute extends Route {
     .then((data) => {
       let check=true
       data.forEach(element => {
-        if (element.templateId==params.docType) {
+        if (element.templateName==params.docType) {
           check=false
         }
       });

--- a/web/app/routes/authenticated/new/doc.js
+++ b/web/app/routes/authenticated/new/doc.js
@@ -15,13 +15,40 @@ export default class AuthenticatedNewDocRoute extends Route {
 
   async model(params) {
     // Validate docType.
-    switch (params.docType) {
-      case "FRD":
-      case "PRD":
-      case "RFC":
-        break;
-      default:
-        this.flashMessages.add({
+    // template-add
+    // switch (params.docType) {
+    //   case "FRD":
+    //   case "PRD":
+    //   case "RFC":
+    //   case "TECHSPEC":
+    //     break;
+    //   default:
+    //     this.flashMessages.add({
+    //       message: `Invalid document type: ${params.docType}`,
+    //       title: "Invalid document type",
+    //       type: "critical",
+    //       timeout: 7000,
+    //       extendedTimeout: 1000,
+    //     });
+    //     this.router.transitionTo("authenticated.new");
+    // }
+
+    //custom-template-add-task-1
+    // fetch all the template id and match with current doctype.
+    // if doctype does not present throw error and move to /new
+
+    this.fetchSvc.fetch("/api/v1/document-types")
+    .then((response) => response.json())
+    .then((data) => {
+      let check=true
+      data.forEach(element => {
+        if (element.templateId==params.docType) {
+          check=false
+        }
+      });
+      if(check)
+      {
+          this.flashMessages.add({
           message: `Invalid document type: ${params.docType}`,
           title: "Invalid document type",
           type: "critical",
@@ -29,7 +56,12 @@ export default class AuthenticatedNewDocRoute extends Route {
           extendedTimeout: 1000,
         });
         this.router.transitionTo("authenticated.new");
-    }
+      }
+    })
+    .catch((error) => {
+      console.error("Error fetching document Types:", error);
+      // Handle any errors that occurred during the fetch request
+    });
 
     return RSVP.hash({
       docType: params?.docType,

--- a/web/app/services/config.ts
+++ b/web/app/services/config.ts
@@ -8,6 +8,7 @@ export default class ConfigService extends Service {
   config = {
     algolia_docs_index_name: config.algolia.docsIndexName,
     algolia_drafts_index_name: config.algolia.draftsIndexName,
+    algolia_template_index_name: config.algolia.templateIndexName,
     algolia_internal_index_name: config.algolia.internalIndexName,
     feature_flags: config.featureFlags,
     google_doc_folders: config.google.docFolders ?? "",

--- a/web/app/templates/authenticated/new/custom-template.hbs
+++ b/web/app/templates/authenticated/new/custom-template.hbs
@@ -1,4 +1,3 @@
-{{!-- custom-template-add --}}
 {{page-title "Create Your Custom Template"}}
 
 <New::TemplateForm @docType="PRD" />

--- a/web/app/templates/authenticated/new/custom-template.hbs
+++ b/web/app/templates/authenticated/new/custom-template.hbs
@@ -1,0 +1,4 @@
+{{!-- custom-template-add --}}
+{{page-title "Create Your Custom Template"}}
+
+<New::TemplateForm @docType="PRD" />

--- a/web/app/templates/authenticated/new/index.hbs
+++ b/web/app/templates/authenticated/new/index.hbs
@@ -8,18 +8,17 @@
       <LinkTo
         class="w-full h-full no-underline"
         @route="authenticated.new.doc"
-        @query={{hash docType=docType.name}}
+        @query={{hash docType=docType.templateId}}
       >
         <Hds::Card::Container
           @level="mid"
           @levelHover="high"
           @hasBorder="true"
-          class="template-card
-            {{if docType.moreInfoLink 'template-card--with-link'}}"
+          class="template-card template-card--with-link"
         >
           <div>
             <p class="text-display-200 text-color-foreground-primary mb-1">
-              {{docType.name}}
+              {{docType.templateId}}
             </p>
             <h2
               class="text-display-400 font-semibold text-color-foreground-strong"
@@ -32,18 +31,37 @@
           </div>
         </Hds::Card::Container>
       </LinkTo>
-      {{#if docType.moreInfoLink}}
-        <Hds::Link::Standalone
-          @isHrefExternal={{true}}
-          @href={{docType.moreInfoLink.url}}
-          @icon="external-link"
-          @iconPosition="trailing"
-          class="small-external-link absolute bottom-6 left-5 whitespace-nowrap z-10"
-          @text={{docType.moreInfoLink.text}}
-        />
-      {{/if}}
     </li>
 
   {{/each}}
+
+  {{!-- custom-template-add --}}
+  <li class="relative">
+      <LinkTo
+        class="w-full h-full no-underline"
+        @route="authenticated.new.custom-template"
+      >
+        <Hds::Card::Container
+          @level="mid"
+          @levelHover="high"
+          @hasBorder="true"
+          class="template-card template-card--with-link"
+        >
+          <div>
+            <p class="text-display-200 text-color-foreground-primary mb-1">
+              Add template
+            </p>
+            <h2
+              class="text-display-400 font-semibold text-color-foreground-strong"
+            >
+              +
+            </h2>
+            <p class="my-2 text-body-200 text-color-foreground-primary">
+              add new custom template
+            </p>
+          </div>
+        </Hds::Card::Container>
+      </LinkTo>
+  </li>
 
 </ol>

--- a/web/app/templates/authenticated/new/index.hbs
+++ b/web/app/templates/authenticated/new/index.hbs
@@ -8,7 +8,7 @@
       <LinkTo
         class="w-full h-full no-underline"
         @route="authenticated.new.doc"
-        @query={{hash docType=docType.templateId}}
+        @query={{hash docType=docType.templateName}}
       >
         <Hds::Card::Container
           @level="mid"
@@ -18,7 +18,7 @@
         >
           <div>
             <p class="text-display-200 text-color-foreground-primary mb-1">
-              {{docType.templateId}}
+              {{docType.templateName}}
             </p>
             <h2
               class="text-display-400 font-semibold text-color-foreground-strong"

--- a/web/config/environment.js
+++ b/web/config/environment.js
@@ -45,6 +45,7 @@ module.exports = function (environment) {
       appID: getEnv("ALGOLIA_APP_ID"),
       docsIndexName: getEnv("ALGOLIA_DOCS_INDEX_NAME", "docs"),
       draftsIndexName: getEnv("ALGOLIA_DRAFTS_INDEX_NAME", "drafts"),
+      templateIndexName: getEnv("ALGOLIA_TEMPLATE_INDEX_NAME","template"),
       internalIndexName: getEnv("ALGOLIA_INTERNAL_INDEX_NAME", "internal"),
       apiKey: getEnv("ALGOLIA_SEARCH_API_KEY"),
     },


### PR DESCRIPTION
Front end Part Of Template Management
1. added routes of custom template form
2. make page containing form for template creation (added 1 file)
3. make template form component (added two files)
4. replaces switch cases with loops
5. added new algolia index named template to store templates

<img width="1131" alt="Screenshot 2023-07-11 at 2 22 47 AM" src="https://github.com/razorpay/hermes/assets/70308421/ae7ba321-56e0-4dc1-afde-2f7307f0614d">
