### PR TITLE
PR #6: Suppresion of  content exporting by the Indexer to algolia

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -3,7 +3,6 @@ package indexer
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"sync"
 	"time"
@@ -423,26 +422,30 @@ func (idx *Indexer) Run() error {
 				os.Exit(1)
 			}
 
+			// Uncomment following lines if you wish to share all of your documents contents to algolia
+			// for indexing
+
 			// Get document content.
-			exp, err := gwSvc.Drive.Files.Export(file.Id, "text/plain").Download()
-			if err != nil {
-				logError("error exporting document", err)
-				os.Exit(1)
-			}
-
-			content, err := io.ReadAll(exp.Body)
-
-			if err != nil {
-				logError("error reading exported document", err)
-				os.Exit(1)
-			}
-			// Trim doc content if it is larger than the maximum size.
-			if len(content) > maxContentSize {
-				content = content[:maxContentSize]
-			}
+			//exp, err := gwSvc.Drive.Files.Export(file.Id, "text/plain").Download()
+			//if err != nil {
+			//	logError("error exporting document", err)
+			//	os.Exit(1)
+			//}
+			//
+			//content, err := io.ReadAll(exp.Body)
+			//
+			//if err != nil {
+			//	logError("error reading exported document", err)
+			//	os.Exit(1)
+			//}
+			//// Trim doc content if it is larger than the maximum size.
+			//if len(content) > maxContentSize {
+			//	content = content[:maxContentSize]
+			//}
 
 			// Update document object with content and latest modified time.
-			docObj.SetContent(string(content))
+			//docObj.SetContent(string(content))
+			docObj.SetContent("NA")
 			docObj.SetModifiedTime(modifiedTime.Unix())
 
 			// Save the document in Algolia.


### PR DESCRIPTION
🚀 **PR 6: Summary:**

The following are the things done in this PR:

1. The suppression of content export to the Algolia cloud, Now no longer any content is loaded and exported to any outside third party.

Thank you! 😊 