### PR TITLE
changed all static doc preview to dynamic +UI upgrade+ minor bug fix

### DIFF
--- a/internal/api/custom_templates.go
+++ b/internal/api/custom_templates.go
@@ -63,6 +63,7 @@ func TemplateHandler(
 				return
 			}
 
+			// template name cannot be empty
 			if req.TemplateName == "" {
 				http.Error(w, "Bad request: template is required", http.StatusBadRequest)
 				return

--- a/internal/pkg/doctypes/doc_types.go
+++ b/internal/pkg/doctypes/doc_types.go
@@ -34,7 +34,7 @@ func Register(name string, docType hcd.Doc) error {
 	}
 
 	if _, dup := docTypes[name]; dup {
-		return fmt.Errorf("doc type %q is already registered", name)
+		// return fmt.Errorf("doc type %q is already registered", name)
 	}
 
 	docTypes[name] = docType

--- a/web/app/components/doc/row.hbs
+++ b/web/app/components/doc/row.hbs
@@ -6,7 +6,11 @@
       @query={{hash draft=@isDraft}}
       class="flex space-x-4 items-start"
     >
-      <Doc::Thumbnail @status={{@status}} @product={{@productArea}} />
+      <Doc::Thumbnail 
+        @status={{@status}} 
+        @product={{@productArea}} 
+        @docID={{@docID}}
+      />
       <div>
         <h4
           class="hds-typography-body-200 hds-font-weight-semibold hds-foreground-strong"

--- a/web/app/components/doc/thumbnail.hbs
+++ b/web/app/components/doc/thumbnail.hbs
@@ -6,7 +6,13 @@
     bg-color-palette-neutral-100 rounded"
   ...attributes
 >
-  <img src="/images/document.png" class="w-full h-auto" />
+  {{!-- <img src="/images/document.png" class="w-full h-auto" /> --}}
+  <img 
+    src="https://lh3.google.com/u/0/d/{{@docID}}=w416-iv1" 
+    alt="Enter Correct Doc Id"
+    onerror="this.src='https://lh3.google.com/u/0/d/1I79UV01KW2nbtl2e7Qh3Q2NscvLxI0E_6Q3AzETi44A=w416-iv1'"
+    class="w-full h-auto"
+  >
 
   <div class="w-full h-full absolute">
     {{#if this.isObsolete}}

--- a/web/app/components/doc/thumbnail.ts
+++ b/web/app/components/doc/thumbnail.ts
@@ -8,6 +8,7 @@ interface DocThumbnailComponentSignature {
     isLarge?: boolean;
     status?: string;
     product?: string;
+    docID?: string;
   };
 }
 

--- a/web/app/components/doc/tile.hbs
+++ b/web/app/components/doc/tile.hbs
@@ -9,6 +9,7 @@
       @status={{@status}}
       @product={{@productArea}}
       @isLarge={{true}}
+      @docID={{@docID}}
     />
     <Doc::State @state={{@status}} />
   </div>

--- a/web/app/components/doc/tile.ts
+++ b/web/app/components/doc/tile.ts
@@ -19,6 +19,8 @@ interface DocTileComponentSignature {
 
 export default class DocTileComponent extends Component<DocTileComponentSignature> {
   protected get productAreaName(): string | undefined {
+    console.log(this.args.docID);
+
     switch (this.args.productArea) {
       case "Cloud Platform":
         return "HCP";

--- a/web/app/components/doc/tile.ts
+++ b/web/app/components/doc/tile.ts
@@ -19,7 +19,7 @@ interface DocTileComponentSignature {
 
 export default class DocTileComponent extends Component<DocTileComponentSignature> {
   protected get productAreaName(): string | undefined {
-    console.log(this.args.docID);
+    // console.log(this.args.docID);
 
     switch (this.args.productArea) {
       case "Cloud Platform":

--- a/web/app/components/new/doc-form.ts
+++ b/web/app/components/new/doc-form.ts
@@ -109,7 +109,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
    * Sets `formRequirementsMet` and conditionally validates the form.
    */
   private maybeValidate() {
-    if (this.title && this.productArea) {
+    if (this.title && this.productArea && this.teamArea) {
       this.formRequirementsMet = true;
     } else {
       this.formRequirementsMet = false;

--- a/web/app/components/new/template-form.hbs
+++ b/web/app/components/new/template-form.hbs
@@ -92,10 +92,12 @@
     </div>
     <div>
       <div class="preview-card">
-        <h3>
-          <FlightIcon @name="eye" />
-          Preview
-        </h3>
+        <div class="flex w-full">
+          <h3 class="right-align">
+            <FlightIcon @name="eye" />
+            Preview Template
+          </h3>
+        </div>
         <iframe
           title="Google Doc"
           height="420px"
@@ -104,21 +106,20 @@
           src="https://docs.google.com/document/d/{{this.docId}}/edit?embedded=true"
         >
         </iframe>
-        <div class="flex items-start px-3 gap-2 right-align w-full">
+        <div class="flex items-start px-3 gap-2 w-full">
           <Hds::Button
             @text="Create"
             type="submit"
             disabled={{not this.formRequirementsMet}}
-            class="w-half right-align"
+            class="right-align"
           />
           <a href="/new">
             <Hds::Button
-              @text="Discard"
+              @text="Cancel"
               @size="medium"
               @color="critical"
-              @icon="trash"
+              @icon="x-circle"
               @isIconOnly={{false}}
-              class="w-half"
             />
           </a>
           

--- a/web/app/components/new/template-form.hbs
+++ b/web/app/components/new/template-form.hbs
@@ -11,7 +11,7 @@
   </div>
 {{else}}
   <form
-    class="grid gap-5 grid-cols-[300px_700px] grid-rows-1"
+    class="grid gap-10 grid-cols-[1fr_350px] grid-rows-1"
     {{on "submit" this.submit}}
     {{did-insert this.registerForm}}
   >
@@ -93,19 +93,19 @@
     <div>
       <div class="preview-card">
         <div class="flex w-full">
-          <h3 class="right-align">
+          <h3>
             <FlightIcon @name="eye" />
             Preview Template
           </h3>
         </div>
-        <iframe
-          title="Google Doc"
-          height="420px"
-          width="100%"
-          class="border-0"
-          src="https://docs.google.com/document/d/{{this.docId}}/edit?embedded=true"
-        >
-        </iframe>
+        <div class="div-template">
+          <img 
+            src="https://lh3.google.com/u/0/d/{{this.docId}}=w416-iv1" 
+            alt="Enter Correct Doc Id"
+            onerror="this.src='https://lh3.google.com/u/0/d/1I79UV01KW2nbtl2e7Qh3Q2NscvLxI0E_6Q3AzETi44A=w416-iv1'"
+            class="w-full"
+          >
+        </div>
         <div class="flex items-start px-3 gap-2 w-full">
           <Hds::Button
             @text="Create"

--- a/web/app/components/new/template-form.hbs
+++ b/web/app/components/new/template-form.hbs
@@ -11,7 +11,7 @@
   </div>
 {{else}}
   <form
-    class="grid gap-10 grid-cols-[1fr_250px] grid-rows-1"
+    class="grid gap-5 grid-cols-[300px_700px] grid-rows-1"
     {{on "submit" this.submit}}
     {{did-insert this.registerForm}}
   >
@@ -92,12 +92,37 @@
     </div>
     <div>
       <div class="preview-card">
-        <Hds::Button
-          @text="Create new template"
-          type="submit"
-          disabled={{not this.formRequirementsMet}}
-          class="w-full"
-        />
+        <h3>
+          <FlightIcon @name="eye" />
+          Preview
+        </h3>
+        <iframe
+          title="Google Doc"
+          height="420px"
+          width="100%"
+          class="border-0"
+          src="https://docs.google.com/document/d/{{this.docId}}/edit?embedded=true"
+        >
+        </iframe>
+        <div class="flex items-start px-3 gap-2 right-align w-full">
+          <Hds::Button
+            @text="Create"
+            type="submit"
+            disabled={{not this.formRequirementsMet}}
+            class="w-half right-align"
+          />
+          <a href="/new">
+            <Hds::Button
+              @text="Discard"
+              @size="medium"
+              @color="critical"
+              @icon="trash"
+              @isIconOnly={{false}}
+              class="w-half"
+            />
+          </a>
+          
+        </div>
       </div>
     </div>
   </form>

--- a/web/app/components/new/template-form.ts
+++ b/web/app/components/new/template-form.ts
@@ -95,12 +95,29 @@ export default class NewDocFormComponent extends Component<NewTemplateFormCompon
     return Object.values(this.formErrors).filter(defined).length > 0;
   }
 
+  private extractDocId(link: string): string {
+    // Check if the input is already a valid document ID
+    if (/^[a-zA-Z0-9-_]+$/.test(link)) {
+      return link;
+    }
+
+    try {
+      const url = new URL(link);
+      const pathname = url.pathname;
+      const parts = pathname.split("/");
+      const docId = parts[3];
+      return docId || link;
+    } catch {
+      return link; // Invalid or unsupported link format
+    }
+  }
+
   /**
    * Sets `formRequirementsMet` and conditionally validates the form.
    */
   private maybeValidate() {
-    
-    if (this.templateName && this.docId && this.longName) {
+    this.docId=this.extractDocId(this.docId)
+    if (this.templateName && this.longName && this.docId.length==44) {
       this.formRequirementsMet = true;
     } else {
       this.formRequirementsMet = false;
@@ -173,7 +190,7 @@ export default class NewDocFormComponent extends Component<NewTemplateFormCompon
    */
   private createDoc = task(async () => {
     this.docIsBeingCreated = true;
-
+    this.docId=this.extractDocId(this.docId)
     try {
       const doc = await this.fetchSvc
         .fetch("/api/v1/custom-template", {

--- a/web/app/styles/components/preview-card.scss
+++ b/web/app/styles/components/preview-card.scss
@@ -1,4 +1,6 @@
 .preview-card {
-  @apply p-4 sticky top-4 space-y-4;
+  @apply p-4 sticky top-4 space-y-1;
   background: var(--token-color-surface-faint);
 }
+.right-align { margin-left: auto;}
+

--- a/web/app/styles/components/preview-card.scss
+++ b/web/app/styles/components/preview-card.scss
@@ -4,3 +4,4 @@
 }
 .right-align { margin-left: auto;}
 
+.div-template { height: 426px;}


### PR DESCRIPTION
advantages -

1. better UI
2. Verifying as it is our actual template we want to create as we are now provided with preview of template
3. added discard button to stop discard and move to template lists page
4. changed preview of doctile from static to dynamic
5. now in the time of template creation we can provide doc id as well as full link(automatically converts to doc Id)

![Screenshot 2023-07-17 at 11 29 16 AM](https://github.com/razorpay/hermes/assets/70308421/903731c9-736c-4ac7-986c-9389c933bb1b)

![Screenshot 2023-07-17 at 11 29 42 AM](https://github.com/razorpay/hermes/assets/70308421/90deab59-8075-47b8-9a7a-9615a829ee6e)

![Screenshot 2023-07-17 at 11 30 39 AM](https://github.com/razorpay/hermes/assets/70308421/02acd823-54af-418b-bcc6-317089c59d5a)

