### PR TITLE
PR #16: 'Project' sub-class inside the teams

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,12 @@
     <option name="autoReloadType" value="ALL" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="04ca871f-2430-458d-a06c-8763ebc8f470" name="Changes" comment="" />
+    <list default="true" id="04ca871f-2430-458d-a06c-8763ebc8f470" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pkg/models/gorm.go" beforeDir="false" afterPath="$PROJECT_DIR$/pkg/models/gorm.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pkg/models/product.go" beforeDir="false" afterPath="$PROJECT_DIR$/pkg/models/product.go" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pkg/models/team.go" beforeDir="false" afterPath="$PROJECT_DIR$/pkg/models/team.go" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -35,12 +40,14 @@
     &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
     &quot;DefaultGoTemplateProperty&quot;: &quot;Go File&quot;,
     &quot;DefaultHtmlFileTemplate&quot;: &quot;HTML File&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.go.formatter.settings.were.checked&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.go.migrated.go.modules.settings&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.go.modules.go.list.on.any.changes.was.set&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.go.vendoring.notification.had.been.shown&quot;: &quot;true&quot;,
     &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;yashcode00/projectFolder&quot;,
     &quot;go.import.settings.migrated&quot;: &quot;true&quot;,
     &quot;go.sdk.automatically.set&quot;: &quot;true&quot;,
     &quot;last_opened_file_path&quot;: &quot;/Users/sharma.yash/Desktop/razorpay/hermes&quot;,
@@ -49,7 +56,8 @@
     &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
     &quot;settings.editor.selected.configurable&quot;: &quot;preferences.pluginManager&quot;,
     &quot;ts.external.directory.path&quot;: &quot;/Users/sharma.yash/Desktop/razorpay/hermes/web/node_modules/typescript/lib&quot;,
-    &quot;ts.rename.search.for.js.occurrences&quot;: &quot;false&quot;
+    &quot;ts.rename.search.for.js.occurrences&quot;: &quot;false&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
 }</component>
   <component name="RecentsManager">
@@ -60,6 +68,19 @@
     </key>
   </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="04ca871f-2430-458d-a06c-8763ebc8f470" name="Changes" comment="" />
+      <created>1690186813767</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1690186813767</updated>
+      <workItem from="1690186814829" duration="8000" />
+      <workItem from="1690186842109" duration="39000" />
+      <workItem from="1690186901880" duration="12000" />
+    </task>
+    <servers />
+  </component>
   <component name="TypeScriptGeneratedFilesManager">
     <option name="version" value="3" />
   </component>

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,16 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/forPelevin/gomoji v1.1.3
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
+	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/golang-jwt/jwt/v5 v5.0.0
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-hclog v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/hcl/v2 v2.11.1
+	github.com/joho/godotenv v1.5.1
 	github.com/mitchellh/cli v1.1.2
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
+	github.com/slack-go/slack v0.12.2
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/oauth2 v0.3.0
 	google.golang.org/api v0.103.0
@@ -38,7 +42,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
@@ -55,7 +58,6 @@ require (
 	github.com/jackc/pgx/v4 v4.17.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
@@ -66,7 +68,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/slack-go/slack v0.12.2 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	golang.org/x/crypto v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,11 +36,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
-github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -53,7 +50,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
-github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
@@ -67,8 +63,8 @@ github.com/go-ozzo/ozzo-validation/v4 v4.3.0/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRi
 github.com/go-sql-driver/mysql v1.7.0 h1:ueSltNNllEqE3qcWBTD0iQd3IpL/6U+mJxLkazJ7YPc=
 github.com/go-sql-driver/mysql v1.7.0/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=

--- a/internal/api/drafts.go
+++ b/internal/api/drafts.go
@@ -31,6 +31,7 @@ type DraftsRequest struct {
 	DocType      string   `json:"docType,omitempty"`
 	Product      string   `json:"product,omitempty"`
 	Team         string   `json:"team,omitempty"`
+	Project      string   `json:"project,omitempty"`
 	Summary      string   `json:"summary,omitempty"`
 	Tags         []string `json:"tags,omitempty"`
 	Title        string   `json:"title"`
@@ -43,6 +44,7 @@ type DraftsPatchRequest struct {
 	Contributors []string `json:"contributors,omitempty"`
 	Product      string   `json:"product,omitempty"`
 	Team         string   `json:"team,omitempty"`
+	Project      string   `json:"project,omitempty"`
 	Summary      string   `json:"summary,omitempty"`
 	// Tags                []string `json:"tags,omitempty"`
 	Title string `json:"title,omitempty"`
@@ -197,6 +199,7 @@ func DraftsHandler(
 				OwnerPhotos:  op,
 				Product:      req.Product,
 				Team:         req.Team,
+				Project:      req.Project,
 				Status:       "Draft",
 				Summary:      req.Summary,
 				Tags:         req.Tags,
@@ -292,6 +295,9 @@ func DraftsHandler(
 				},
 				Team: models.Team{
 					Name: req.Team,
+				},
+				Project: models.Project{
+					Name: req.Project,
 				},
 				Status:  models.DraftDocumentStatus,
 				Summary: req.Summary,

--- a/internal/api/projects.go
+++ b/internal/api/projects.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp-forge/hermes/internal/config"
+	"github.com/hashicorp-forge/hermes/pkg/algolia"
+	"github.com/hashicorp-forge/hermes/pkg/models"
+	"github.com/hashicorp/go-hclog"
+	"gorm.io/gorm"
+)
+
+type ProjectRequest struct {
+	ProjectName string `json:"name,omitempty"`
+	TeamName    string `json:"team,omitempty"`
+}
+
+// ProjectsHandler handles the post req to add new projects from the Hermes frontend.
+func ProjectsHandler(cfg *config.Config, ar *algolia.Client,
+	aw *algolia.Client, db *gorm.DB, log hclog.Logger) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// ONly allow the post requests
+		if r.Method != "POST" {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		// Decode request.
+		var req ProjectRequest
+		if err := decodeRequest(r, &req); err != nil {
+			log.Error("error decoding projects request", "error", err)
+			http.Error(w, fmt.Sprintf("Bad request: %q", err),
+				http.StatusBadRequest)
+			return
+		}
+
+		// Add the data to the Postgres Database
+		err := CreateNewProject(ar, aw, db, req)
+		if err != nil {
+			log.Error("error inserting new Projects", "error", err)
+			http.Error(w, "Error inserting projects",
+				http.StatusInternalServerError)
+			return
+		}
+
+		// Send success response
+		// Send success response with success message
+		response := struct {
+			Message string `json:"message"`
+		}{
+			Message: "New Project Inserted successfully",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		enc := json.NewEncoder(w)
+		err = enc.Encode(response)
+		if err != nil {
+			log.Error("error encoding projects response", "error", err)
+			http.Error(w, "Error posting project",
+				http.StatusInternalServerError)
+			return
+		}
+
+	})
+}
+
+// Function to add new projects inside pre-existing team in the
+// Database
+func CreateNewProject(ar *algolia.Client,
+	aw *algolia.Client, db *gorm.DB, req ProjectRequest) error {
+	// Find the team with the given name in the database.
+	team := &models.Team{}
+	if err := db.Where("name = ?", req.TeamName).First(team).Error; err != nil {
+		return fmt.Errorf("failed to find team: %w", err)
+	}
+
+	// Create a new project associated with the team.
+	err := team.AddProject(db, req.ProjectName)
+	if err != nil {
+		return fmt.Errorf("error creating project: %w", err)
+	}
+
+	// Save the team/ Update
+	if err := SaveTeam(db, team); err != nil {
+		return fmt.Errorf("error saving the update team: %w", err)
+	}
+
+	return nil
+}
+
+// SaveTeam saves the updated team to the database.
+func SaveTeam(db *gorm.DB, team *models.Team) error {
+	if err := db.Save(team).Error; err != nil {
+		return fmt.Errorf("error saving team: %w", err)
+	}
+	return nil
+}

--- a/internal/cmd/commands/server/server.go
+++ b/internal/cmd/commands/server/server.go
@@ -426,6 +426,7 @@ func (c *Command) Run(args []string) int {
 		{"/api/v1/people", api.PeopleDataHandler(cfg, c.Log, goog)},
 		{"/api/v1/products", api.ProductsHandler(cfg, algoSearch, algoWrite, db, c.Log)},
 		{"/api/v1/teams", api.TeamsHandler(cfg, algoSearch, algoWrite, db, c.Log)},
+		{"/api/v1/projects", api.ProjectsHandler(cfg, algoSearch, algoWrite, db, c.Log)},
 		{"/api/v1/reviews/",
 			api.ReviewHandler(cfg, c.Log, algoSearch, algoWrite, goog, db)},
 		{"/api/v1/web/analytics", api.AnalyticsHandler(c.Log)},

--- a/pkg/hashicorpdocs/basedoc.go
+++ b/pkg/hashicorpdocs/basedoc.go
@@ -81,6 +81,9 @@ type BaseDoc struct {
 	// Team is the team/pods that the document relates to.
 	Team string `json:"team,omitempty"`
 
+	// Project is the project that the document relates to
+	Project string `json:"project,omitempty"`
+
 	// Summary is a summary of the document.
 	Summary string `json:"summary,omitempty"`
 
@@ -150,6 +153,10 @@ func (d BaseDoc) GetProduct() string {
 
 func (d BaseDoc) GetTeam() string {
 	return d.Team
+}
+
+func (d BaseDoc) GetProject() string {
+	return d.Project
 }
 
 func (d BaseDoc) GetStatus() string {

--- a/pkg/hashicorpdocs/common.go
+++ b/pkg/hashicorpdocs/common.go
@@ -31,6 +31,7 @@ type Doc interface {
 	GetOwners() []string
 	GetProduct() string
 	GetTeam() string
+	GetProject() string
 	GetStatus() string
 	GetSummary() string
 	GetTitle() string

--- a/pkg/models/document.go
+++ b/pkg/models/document.go
@@ -62,6 +62,10 @@ type Document struct {
 	Team   Team
 	TeamID uuid.UUID `gorm:"index"` // Foreign key column referencing the teams table
 
+	// Project is the project inside specific team
+	Project   Project
+	ProjectID uuid.UUID `gorm:"index"` // Foreign key column referencing the projects table
+
 	// Status is the status of the document.
 	Status DocumentStatus
 
@@ -334,6 +338,23 @@ func (d *Document) createAssocations(db *gorm.DB) error {
 		d.TeamID = d.Team.ID
 	}
 
+	// Get project if project id is not set.
+	if d.ProjectID == uuid.Nil && d.Project.Name != "" {
+		// Search for the project by its ID in the project table.
+		project := d.Project
+		if err := db.
+			Where(project).
+			Preload(clause.Associations).
+			First(&project).
+			Error; err != nil {
+			return fmt.Errorf("error getting project: %w", err)
+		}
+
+		// Assign the found project to the document's Project field.
+		d.Project = project
+		d.ProjectID = project.ID
+	}
+
 	return nil
 }
 
@@ -411,11 +432,29 @@ func (d *Document) getAssociations(db *gorm.DB) error {
 		d.ProductID = d.Product.ID
 	}
 
+	// get team
 	if d.Team.Name != "" {
 		if err := d.Team.Get(db); err != nil {
 			return fmt.Errorf("error getting product: %w", err)
 		}
 		d.TeamID = d.Team.ID
+	}
+
+	// Get project if project id is not set.
+	if d.Project.Name != "" {
+		// Search for the project by its ID in the project table.
+		project := d.Project
+		if err := db.
+			Where(project).
+			Preload(clause.Associations).
+			First(&project).
+			Error; err != nil {
+			return fmt.Errorf("error getting project: %w", err)
+		}
+
+		// Assign the found project to the document's Project field.
+		d.Project = project
+		d.ProjectID = project.ID
 	}
 
 	return nil

--- a/pkg/models/gorm.go
+++ b/pkg/models/gorm.go
@@ -13,5 +13,7 @@ func ModelsToAutoMigrate() []interface{} {
 		&ProductLatestDocumentNumber{},
 		&User{},
 		&Team{},
+		&Project{},
+		&TeamProject{},
 	}
 }

--- a/pkg/models/product.go
+++ b/pkg/models/product.go
@@ -23,7 +23,7 @@ type Product struct {
 	UserSubscribers []User `gorm:"many2many:user_product_subscriptions;"`
 
 	// Teams is the list of teams associated with the BU.
-	Teams []Team `gorm:"foreignKey:BUID;constraint:Teams_BU_mapping"`
+	Teams []Team `gorm:"foreignKey:BUID;"`
 }
 
 // FirstOrCreate finds the first product by name or creates a record if it does

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type Project struct {
+	ID        uuid.UUID `gorm:"type:uuid;default:uuid_generate_v4();primaryKey"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt gorm.DeletedAt `gorm:"index"`
+
+	// Name is the name of the project
+	Name string `gorm:"default:null;index;not null;type:citext;unique"`
+
+	// TeamID is the foreign key to the Team that this project belongs to
+	TeamID uuid.UUID `gorm:"type:uuid;index;not null"`
+
+	// Team is the Team that this project belongs to
+	Team Team `gorm:"foreignKey:TeamID"`
+}

--- a/web/app/components/document/sidebar.hbs
+++ b/web/app/components/document/sidebar.hbs
@@ -157,6 +157,27 @@
             />
           {{/if}}
 
+          <small
+            class="hds-typography-body-100 hds-foreground-faint"
+          >Project</small>
+          {{#if this.isDraft}}
+            <div class="w-full relative">
+              <Inputs::ProjectSelect
+                @onChange={{this.updateProject.perform}}
+                @isSaving={{this.save.isRunning}}
+                @formatIsBadge={{true}}
+                @renderOut={{true}}
+                @selectedteam={{this.team}}
+                @selected={{this.project}}
+              />
+            </div>
+          {{else}}
+            <Hds::Badge
+              @text={{@document.project}}
+              @icon={{get-product-id @document.product}}
+            />
+          {{/if}}
+
         </div>
 
         <div class="flex flex-col items-start space-y-2">

--- a/web/app/components/document/sidebar.ts
+++ b/web/app/components/document/sidebar.ts
@@ -63,6 +63,7 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
   @tracked reviewers = this.args.document.reviewers || [];
   @tracked product = this.args.document.product || "";
   @tracked team = this.args.document.team || "";
+  @tracked project = this.args.document.project || "";
 
   @tracked userHasScrolled = false;
   @tracked _body: HTMLElement | null = null;
@@ -255,6 +256,12 @@ export default class DocumentSidebarComponent extends Component<DocumentSidebarC
   updateTeam = restartableTask(async (team: string) => {
     this.team = team;
     await this.save.perform("team", this.team);
+    // productAbbreviation is computed by the back end
+  });
+
+  updateProject = restartableTask(async (project: string) => {
+    this.project = project;
+    await this.save.perform("project", this.project);
     // productAbbreviation is computed by the back end
   });
 

--- a/web/app/components/inputs/project-select/index.hbs
+++ b/web/app/components/inputs/project-select/index.hbs
@@ -1,0 +1,80 @@
+{{! @glint-nocheck - not typesafe yet }}
+{{! https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/ }}
+<div data-test-product-select>
+  {{#if this.teams}}
+    {{#if @formatIsBadge}}
+      <Inputs::BadgeDropdownList
+        @items={{this.filteredOptions}}
+        @listIsOrdered={{true}}
+        @onItemClick={{this.onChange}}
+        @selected={{@selected}}
+        @placement={{@placement}}
+        @isSaving={{@isSaving}}
+        @renderOut={{@renderOut}}
+        @icon={{this.icon}}
+        class="w-80 product-select-dropdown-list"
+        ...attributes
+      >
+        <:item as |dd|>
+          <dd.Action data-test-product-select-badge-dropdown-item>
+            <Inputs::ProductSelect::Item
+              @product={{dd.value}}
+              @selected={{dd.selected}}
+            />
+          </dd.Action>
+        </:item>
+      </Inputs::BadgeDropdownList>
+    {{else}}
+      <X::DropdownList
+        @items={{this.filteredOptions}}
+        @listIsOrdered={{true}}
+        @onItemClick={{this.onChange}}
+        @selected={{@selected}}
+        @placement={{@placement}}
+        @isSaving={{@isSaving}}
+        @renderOut={{@renderOut}}
+        class="w-[300px] product-select-dropdown-list"
+        ...attributes
+      >
+        <:anchor as |dd|>
+          <dd.ToggleAction
+            class="x-dropdown-list-toggle-select product-select-default-toggle hds-button hds-button--color-secondary hds-button--size-medium"
+          >
+            <FlightIcon @name="collections" />
+
+            <span
+              class="product-select-selected-value
+                {{unless @selected 'text-color-foreground-faint'}}"
+            >
+              {{or @selected "Select your Project"}}
+            </span>
+
+            {{#if this.selectedProductAbbreviation}}
+              <span class="product-select-toggle-abbreviation">
+                {{this.selectedProductAbbreviation}}
+              </span>
+            {{/if}}
+
+            <FlightIcon @name="caret" class="product-select-toggle-caret" />
+          </dd.ToggleAction>
+        </:anchor>
+        <:item as |dd|>
+          <dd.Action class="pr-5">
+            <Inputs::ProjectSelect::Item
+              @product={{dd.value}}
+              @selected={{dd.selected}}
+              @abbreviation={{dd.attrs.abbreviation}}
+            />
+          </dd.Action>
+        </:item>
+      </X::DropdownList>
+    {{/if}}
+  {{else if this.fetchprojects.isRunning}}
+    <FlightIcon data-test-product-select-spinner @name="loading" />
+  {{else}}
+    <div
+      class="absolute top-0 left-0"
+      {{did-insert (perform this.fetchprojects)}}
+    ></div>
+  {{/if}}
+</div>

--- a/web/app/components/inputs/project-select/index.ts
+++ b/web/app/components/inputs/project-select/index.ts
@@ -1,0 +1,93 @@
+import { assert } from "@ember/debug";
+import {action, computed} from "@ember/object";
+import { inject as service } from "@ember/service";
+import { Placement } from "@floating-ui/dom";
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { task } from "ember-concurrency";
+import FetchService from "hermes/services/fetch";
+import getProductId from "hermes/utils/get-product-id";
+
+interface InputsProjectSelectSignature {
+  Element: HTMLDivElement;
+  Args: {
+    selectedteam: string | null;
+    selected?: string;
+    onChange: (value: string, attributes?: TeamArea) => void;
+    formatIsBadge?: boolean;
+    placement?: Placement;
+    isSaving?: boolean;
+    renderOut?: boolean;
+  };
+}
+
+type TeamAreas = {
+  [key: string]: TeamArea;
+};
+
+export type TeamArea = {
+  abbreviation: string;
+  perDocDataType: unknown;
+  BU: string;
+  projects: ProjectAreas;
+};
+
+type ProjectAreas = {
+  [key: string]: ProjectAreas;
+ };
+
+ export type ProjectArea = {
+  teamid: string;
+};
+
+
+export default class InputsProjectSelectComponent extends Component<InputsProjectSelectSignature> {
+  @service("fetch") declare fetchSvc: FetchService;
+
+  @tracked selected = this.args.selected;
+  @tracked teams: TeamAreas | undefined = undefined;
+
+  get icon(): string {
+    let icon = "folder";
+    if (this.selected && getProductId(this.selected)) {
+      icon = getProductId(this.selected) as string;
+    }
+    return icon;
+  }
+
+  @action onChange(newValue: any, attributes?: TeamArea) {
+    this.selected = newValue;
+    this.args.onChange(newValue, attributes);
+  }
+
+  @computed('args.selectedteam', 'teams')
+  get filteredOptions() {
+    if (!this.args.selectedteam) {
+      return {};
+    }
+    // else return the correstponding projects present in the 
+    // team selected
+    const teams: TeamAreas | undefined = this.teams;
+    if (teams){
+      return teams[this.args.selectedteam]?.projects;
+    }
+  }
+
+    protected fetchprojects = task(async () => {
+      try {
+        // Filter the teams based on the selected business unit
+        this.teams = await this.fetchSvc
+            .fetch("/api/v1/teams")
+            .then((resp) => resp?.json());
+        } catch (err) {
+          throw err;
+        }
+      });
+
+}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    "Inputs::ProjectSelect": typeof InputsProjectSelectComponent;
+  }
+}

--- a/web/app/components/inputs/project-select/item.hbs
+++ b/web/app/components/inputs/project-select/item.hbs
@@ -1,0 +1,33 @@
+{{!  @glint-nocheck - not typesafe yet }}
+<div
+  data-test-product-select-item
+  class="relative flex w-full product-select-item"
+  ...attributes
+>
+  <FlightIcon
+    data-test-product-select-item-icon
+    data-test-icon={{or (get-product-id @product) "folder"}}
+    @name="collections"
+  />
+
+  <span data-test-product-select-item-value class="flex ml-2.5 leading-none">
+    {{@product}}
+  </span>
+
+  {{#if @abbreviation}}
+    <span
+      data-test-product-select-item-abbreviation
+      class="opacity-50 inline-flex ml-2 text-body-100 leading-none"
+    >
+      {{@abbreviation}}
+    </span>
+  {{/if}}
+
+  {{#if @selected}}
+    <FlightIcon
+      data-test-product-select-item-selected
+      @name="check"
+      class="check absolute right-0 top-1/2 -translate-y-1/2"
+    />
+  {{/if}}
+</div>

--- a/web/app/components/inputs/project-select/item.ts
+++ b/web/app/components/inputs/project-select/item.ts
@@ -1,0 +1,19 @@
+import Component from "@glimmer/component";
+import InputsProjectSelectComponent from "hermes/components/inputs/project-select/index";
+
+interface InputsProjectSelectItemComponentSignature {
+  Element: HTMLDivElement;
+  Args: {
+    product: string;
+    selected: boolean;
+    abbreviation?: boolean;
+  };
+}
+
+export default class InputsProjectSelectItemComponent extends Component<InputsProjectSelectItemComponentSignature> {}
+
+declare module "@glint/environment-ember-loose/registry" {
+  export default interface Registry {
+    "Inputs::ProjectSelect::Item": typeof InputsProjectSelectComponent;
+  }
+}

--- a/web/app/components/new/doc-form.hbs
+++ b/web/app/components/new/doc-form.hbs
@@ -96,6 +96,25 @@
           />
         </div>
 
+        <div>
+          <div class="mb-2">
+            <span class="hermes-form-label">
+             Project
+              <Hds::Badge @size="small" @text="Required" />
+            </span>
+            <span class="hermes-form-helper-text hds-form-helper-text">
+              Select your Project or Create a new one from dashboard
+            </span>
+          </div>
+          <Inputs::ProjectSelect
+                  @selectedteam={{this.teamArea}}
+                  @selected={{this.projectArea}}
+                  @onChange={{this.onProjectSelect}}
+                  class="w-[300px]"
+          />
+        </div>
+
+
         {{! Note: We are still refining the subscribe/follow feature set.
                 As part of that effort we will be looking into how the concept
                 of "tags" would be useful. For now, we are choosing to

--- a/web/app/components/new/doc-form.ts
+++ b/web/app/components/new/doc-form.ts
@@ -53,6 +53,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
   @tracked protected productAbbreviation: string | null = null;
   @tracked protected teamArea: string | null = null;
   @tracked protected teamAbbreviation: string | null = null;
+  @tracked protected projectArea: string| null = null;
   @tracked protected contributors: HermesUser[] = [];
 
   @tracked selectedBU: string | null = null;
@@ -109,7 +110,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
    * Sets `formRequirementsMet` and conditionally validates the form.
    */
   private maybeValidate() {
-    if (this.title && this.productArea && this.teamArea) {
+    if (this.title && this.productArea && this.teamArea && this.projectArea)  {
       this.formRequirementsMet = true;
     } else {
       this.formRequirementsMet = false;
@@ -184,16 +185,20 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
   ) {
     this.productArea = productName;
     this.selectedBU = productName;
-    this.productAbbreviation = attributes.abbreviation;
     this.maybeValidate();
   }
 
   @action protected onTeamSelect(
       teamName: string,
-      attributes: TeamArea
   ) {
     this.teamArea = teamName;
-    this.teamAbbreviation = attributes.abbreviation;
+    this.maybeValidate();
+  }
+
+  @action protected onProjectSelect(
+    projectName: string,
+  ) {
+    this.projectArea = projectName;
     this.maybeValidate();
   }
 
@@ -234,6 +239,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
             docType: this.args.docType,
             product: this.productArea,
             team: this.teamArea,
+            project: this.projectArea,
             productAbbreviation: this.productAbbreviation,
             teamAbbreviation: this.teamAbbreviation,
             summary: cleanString(this.summary),

--- a/web/app/components/new/doc-form.ts
+++ b/web/app/components/new/doc-form.ts
@@ -18,7 +18,6 @@ import {TeamArea} from "hermes/components/inputs/team-select";
 interface DocFormErrors {
   title: string | null;
   summary: string | null;
-  productAbbreviation: string | null;
   tags: string | null;
   contributors: string | null;
 }
@@ -26,7 +25,6 @@ interface DocFormErrors {
 const FORM_ERRORS: DocFormErrors = {
   title: null,
   summary: null,
-  productAbbreviation: null,
   tags: null,
   contributors: null,
 };
@@ -50,9 +48,7 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
   @tracked protected title: string = "";
   @tracked protected summary: string = "";
   @tracked protected productArea: string | null = null;
-  @tracked protected productAbbreviation: string | null = null;
   @tracked protected teamArea: string | null = null;
-  @tracked protected teamAbbreviation: string | null = null;
   @tracked protected projectArea: string| null = null;
   @tracked protected contributors: HermesUser[] = [];
 
@@ -125,12 +121,6 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
    */
   private validate() {
     const errors = { ...FORM_ERRORS };
-    if (this.productAbbreviation) {
-      if (/\d/.test(this.productAbbreviation)) {
-        errors.productAbbreviation =
-          "Product abbreviation can't include a number";
-      }
-    }
     this.formErrors = errors;
   }
 
@@ -240,8 +230,6 @@ export default class NewDocFormComponent extends Component<NewDocFormComponentSi
             product: this.productArea,
             team: this.teamArea,
             project: this.projectArea,
-            productAbbreviation: this.productAbbreviation,
-            teamAbbreviation: this.teamAbbreviation,
             summary: cleanString(this.summary),
             title: cleanString(this.title),
           }),

--- a/web/app/templates/authenticated/dashboard.hbs
+++ b/web/app/templates/authenticated/dashboard.hbs
@@ -33,6 +33,13 @@
           {{on "click"  (fn this.toggleModal3)}}
   />
 
+  <Hds::Button
+          @text="Project"
+          @icon="collections"
+          @color="secondary"
+          {{on "click"  (fn this.toggleModal4)}}
+  />
+
   </Hds::ButtonSet>
   <br>
       {{/if}}
@@ -232,6 +239,100 @@
 
   {{/modal-dialog}}
   {{/if}}
+
+
+  {{#if this.showModal4}}
+    {{#modal-dialog
+  onClose=(action (action (mut this.showModal4) false))
+  targetAttachment="center"
+  translucentOverlay=true
+  }}
+    <div class="modal-body">
+       <div class="space-y-4" style="text-align: center;">
+          <h4 class="modal-title">Create New Project</h4>
+        </div>
+        <form {{on "submit" this.submitFormProject}}>
+            <div class="mb-4">
+              <div class="mb-2">
+                <span class="hermes-form-label">
+                  Business Unit (BU) &nbsp;
+                  <Hds::Badge @size="small" @text="Required" />
+                </span>
+                <span class="hermes-form-helper-text hds-form-helper-text">
+                  Where your doc should be categorized.
+                </span>
+              </div>
+              <Inputs::ProductSelect
+                @selected={{this.ProjectBU}}
+                @onChange={{this.onProductSelect}}
+                @onSelectBU={{this.updateSelectedBU}}
+                class="w-[300px]"
+              />
+            </div>
+
+            <div class="mb-4">
+              <div class="mb-2">
+                <span class="hermes-form-label">
+                  Teams/Pod
+                  <Hds::Badge @size="small" @text="Required" />
+                </span>
+                <span class="hermes-form-helper-text hds-form-helper-text">
+                  Select your Team/Pod
+                </span>
+              </div>
+              <Inputs::TeamSelect
+                      @selectedBU={{this.selectedBU}}
+                      @selected={{this.ProjectTeamName}}
+                      @onChange={{this.onTeamSelect}}
+                      class="w-[300px]"
+              />
+            </div>
+
+            <div class="mb-4" >
+              <label class="hds-form-label hds-typography-body-200 hds-font-weight-semibold hds-form-field__label" for="team-name"> Project Name:
+                    <div class="hds-badge hds-badge--size-small hds-badge--type-filled hds-badge--color-neutral hds-form-indicator" aria-hidden="true">
+                      <!---->    <div class="hds-badge__text">
+                        Required
+                    </div>
+                  </div>
+                </label>
+                <div class="input-group">
+                <span class="input-group-text">
+                  <i class="bi bi-person-fill fs-5"></i>
+                </span>
+                  <input type="text" class="hds-form-text-input hds-typography-body-200 hds-font-weight-regular hds-form-field__control"  name="project-name" required placeholder="Enter Project Name" >
+                </div>
+            </div>  
+            
+             <div class="modal-footer" class="space-y-4">
+              <Hds::ButtonSet>
+                {{#if this.ProjectIsBeingCreated }}
+                <Hds::Button
+                        @isIconOnly={{true}}
+                        @text="Submit"
+                        @icon="loading"
+                />
+                {{else}}
+                <Hds::Button
+                        @text="Submit"
+                        type="submit"
+                />
+                {{/if}}
+                <Hds::Button
+                        @text="Cancel"
+                        @color="critical"
+                        {{on "click" (fn this.toggleModal4 false)}}
+                />
+              </Hds::ButtonSet>
+            </div>
+         
+      </form>
+      </div>
+
+  {{/modal-dialog}}
+  {{/if}}
+
+
 
   {{#if this.docsWaitingForReview}}
     <div

--- a/web/app/types/document.d.ts
+++ b/web/app/types/document.d.ts
@@ -10,6 +10,7 @@ export interface HermesDocument {
   status: string;
   product?: string;
   team?: string;
+  project?: string;
   modifiedAgo: string;
   modifiedTime: number;
   docNumber: string;


### PR DESCRIPTION
🚀 **PR 16: Summary:**

The following are the things done in this PR:
1. This PR was aimed to introduce a new subfolder class inside the old style: `BU -> Team -> Template -> **Project** -> docx`.
2. The additional feature is complete and working in this PR.
3. The front end now had a new button that allows any user to add a new Project to a specified team. 
4. The new Project Dropdown was also made in the front which auto filters based on the selected Team which is filtered itself based on the selected BU.
5. New Table 'projects' was made in the Postgres database along with all the referential integrity constraints respected and association was made with the teams.
6. A new API was made to handle the addition of new project.
7. The Get request is not required as they are associated with the teams, so when teams are retrieved they are the side product.
8. The backend creation of drafts, and docs now incorporate the new projects attribute.
9. The frontend form while creating a new draft now considers the new 'project' with the same dropdown feature.
Thanks 😊 
